### PR TITLE
Add support for timeout during read operations

### DIFF
--- a/i2c_devicetree.txt
+++ b/i2c_devicetree.txt
@@ -8,5 +8,6 @@ i2c0: i2c@ffd71000 {
         nxp,nxpnfc-irq = <&gpio26 0 0>;
         nxp,nxpnfc-ven = <&gpio26 2 0>;
         nxp,nxpnfc-fw-dwnld = <&gpio26 4 0>;
+        nxp,nxpnfc-read-timeout = <1000>;
     };
 };

--- a/nfc/common.c
+++ b/nfc/common.c
@@ -28,6 +28,7 @@ int nfc_parse_dt(struct device *dev, struct platform_configs *nfc_configs,
 {
 	struct device_node *np = dev->of_node;
 	struct platform_gpio *nfc_gpio = &nfc_configs->gpio;
+	u32 timeout;
 
 	if (!np) {
 		pr_err("%s: nfc of_node NULL\n", __func__);
@@ -37,6 +38,7 @@ int nfc_parse_dt(struct device *dev, struct platform_configs *nfc_configs,
 	nfc_gpio->irq = -EINVAL;
 	nfc_gpio->dwl_req = -EINVAL;
 	nfc_gpio->ven = -EINVAL;
+	nfc_configs->timeout = 0;
 
 	/* irq required for i2c based chips only */
 	if (interface == PLATFORM_IF_I2C || interface == PLATFORM_IF_SPI) {
@@ -58,9 +60,12 @@ int nfc_parse_dt(struct device *dev, struct platform_configs *nfc_configs,
 	if ((!gpio_is_valid(nfc_gpio->dwl_req)))
 		pr_warn("%s: dwl_req gpio invalid %d\n", __func__,
 			nfc_gpio->dwl_req);
+	/* timeout during read operations */
+	if( 0  == of_property_read_u32(np, DTS_TIMEOUT_STR, &timeout) )
+		nfc_configs->timeout = (int)timeout;
 
-	pr_info("%s: %d, %d, %d\n", __func__, nfc_gpio->irq, nfc_gpio->ven,
-		nfc_gpio->dwl_req);
+	pr_info("%s: %d, %d, %d, %d\n", __func__, nfc_gpio->irq, nfc_gpio->ven,
+		nfc_gpio->dwl_req, nfc_configs->timeout);
 	return 0;
 }
 

--- a/nfc/common.h
+++ b/nfc/common.h
@@ -87,6 +87,7 @@
 #define DTS_IRQ_GPIO_STR		"nxp,nxpnfc-irq"
 #define DTS_VEN_GPIO_STR		"nxp,nxpnfc-ven"
 #define DTS_FWDN_GPIO_STR		"nxp,nxpnfc-fw-dwnld"
+#define DTS_TIMEOUT_STR			"nxp,nxpnfc-read-timeout"
 
 enum nfcc_ioctl_request {
 	/* NFC disable request with VEN LOW */
@@ -152,6 +153,7 @@ struct platform_gpio {
 /* NFC Struct to get all the required configs from DTS */
 struct platform_configs {
 	struct platform_gpio gpio;
+	int timeout;
 };
 
 /* Device specific structure */

--- a/nfc/i2c_drv.c
+++ b/nfc/i2c_drv.c
@@ -130,8 +130,8 @@ int i2c_read(struct nfc_dev *nfc_dev, char *buf, size_t count, int timeout)
 						msecs_to_jiffies(timeout));
 
 					if (ret <= 0) {
-						pr_err("%s: timeout error\n",
-						       __func__);
+						// pr_err("%s: timeout error\n",
+						//        __func__);
 						goto err;
 					}
 				} else {
@@ -226,7 +226,7 @@ ssize_t nfc_i2c_dev_read(struct file *filp, char __user *buf, size_t count,
 		return -EAGAIN;
 	}
 	mutex_lock(&nfc_dev->read_mutex);
-	ret = i2c_read(nfc_dev, nfc_dev->read_kbuf, count, 0);
+	ret = i2c_read(nfc_dev, nfc_dev->read_kbuf, count, nfc_dev->configs.timeout);
 	if (ret > 0) {
 		if (copy_to_user(buf, nfc_dev->read_kbuf, ret)) {
 			pr_warn("%s: failed to copy to user space\n", __func__);

--- a/nfc/spi_drv.c
+++ b/nfc/spi_drv.c
@@ -144,7 +144,6 @@ static irqreturn_t spi_irq_handler(int irq, void *dev_id)
 int nfc_spi_read(struct nfc_dev *nfc_dev, char *buf, size_t count, int timeout)
 {
 	int ret;
-	int cmd_length = 0;
 	struct spi_dev *spi_dev = &nfc_dev->spi_dev;
 	struct platform_gpio *nfc_gpio = &nfc_dev->configs.gpio;
 
@@ -171,8 +170,8 @@ int nfc_spi_read(struct nfc_dev *nfc_dev, char *buf, size_t count, int timeout)
 						msecs_to_jiffies(timeout));
 
 					if (ret <= 0) {
-						pr_err("%s: timeout error\n",
-						       __func__);
+						// pr_err("%s: timeout error\n",
+						//        __func__);
 						goto err;
 					}
 				} else {
@@ -293,7 +292,7 @@ ssize_t nfc_spi_dev_read(struct file *filp, char __user *buf, size_t count,
 		return -EAGAIN;
 	}
 	mutex_lock(&nfc_dev->read_mutex);
-	ret = nfc_spi_read(nfc_dev, nfc_dev->read_kbuf, count, 0);
+	ret = nfc_spi_read(nfc_dev, nfc_dev->read_kbuf, count, nfc_dev->configs.timeout);
 	if (ret > 0) {
 		if (copy_to_user(buf, nfc_dev->read_kbuf, ret)) {
 			pr_warn("%s: failed to copy to user space\n", __func__);

--- a/spi_devicetree.txt
+++ b/spi_devicetree.txt
@@ -8,6 +8,7 @@ spi2: spi@ffd68000 {
 		nxp,nxpnfc-irq = <&gpio26 0 0>;
 		nxp,nxpnfc-ven = <&gpio26 2 0>;
 		nxp,nxpnfc-fw-dwnld = <&gpio26 4 0>;
+        nxp,nxpnfc-read-timeout = <1000>;
 		spi-max-frequency = <7000000>;
     };
 };


### PR DESCRIPTION
If NFC chip is not responding, the read operations can be blocking.

This PR implement :
- timeout is defined in device tree with `nxp,nxpnfc-read-timeout`. If omitted the timeout is set to 0 (disabled).
- timeout for I2C & SPI read operations.

Tested with a PN7160.